### PR TITLE
Support git-next's "authtype" capability

### DIFF
--- a/git-credential-msal
+++ b/git-credential-msal
@@ -56,6 +56,13 @@ def read_stdin_pairs() -> dict[str, str]:
     return kvs
 
 
+def authtype_accepted(helper_pairs: dict[str, str]) -> bool:
+    if not "capability" in helper_pairs:
+        return False
+
+    return "authtype" in helper_pairs["capability"]
+
+
 def bearer_accepted(helper_pairs: dict[str, str]) -> bool:
     if not "wwwauth" in helper_pairs:
         return False
@@ -226,6 +233,7 @@ def msal_acquire_oidc_id_token(
     put_http_cache(http_cache)
     return id_token
 
+
 parser = argparse.ArgumentParser(
     prog="git-credential-msal",
     description="git-credential-helper for Microsoft SSO auth flows using MSAL",
@@ -240,6 +248,10 @@ if args.command != "get":
     exit(0)
 
 helper_pairs = read_stdin_pairs()
+
+# Make sure the git implementation supports the `authtype` token.
+if not authtype_accepted(helper_pairs):
+    exit(0)
 
 # Make sure the server specified that a Bearer token is acceptable.
 if not bearer_accepted(helper_pairs):
@@ -272,5 +284,7 @@ os.set_inheritable(1, False)
 id_token = msal_acquire_oidc_id_token(client_id, tenant_id, args.device_code)
 expiry = jwt_expired_value(id_token)
 
-print(f"bearer_token={id_token}")
+print("capability[]=authtype")
+print("authtype=Bearer")
+print(f"credential={id_token}")
 print(f"password_expiry_utc={expiry}")


### PR DESCRIPTION
Git commit c5c9acf77d9 merged support for credential helpers specifying different authentication types. Look for the new "capability[]" array and check if it contains "authtype". Emit the credential in the new format.