### PR TITLE
Isolate keyring instances based on tenant-id and client-id

### DIFF
--- a/git-credential-msal
+++ b/git-credential-msal
@@ -25,9 +25,6 @@ import sys
 # pip install pyxdg
 import xdg.BaseDirectory
 
-keyring_name = "git-credential-msal"
-http_cache_path = os.path.join(xdg.BaseDirectory.xdg_cache_home, keyring_name)
-
 wwwauth_bearer_matcher = re.compile(r"^Bearer(?:\s*|\s+.+)")
 wwwauth_client_id_matcher = re.compile(
     r""".*msal-client-id(?:="(.*?)"|=(.*?),|=(.*))"""
@@ -134,9 +131,9 @@ def extract_entra_ids_from_git_config(helper_pairs: dict[str, str]) -> tuple[str
     return (msal_client_id, msal_tenant_id)
 
 
-def get_msal_cache() -> SerializableTokenCache:
+def get_msal_cache(name: str) -> SerializableTokenCache:
     cache = SerializableTokenCache()
-    data = keyring.get_password("system", keyring_name)
+    data = keyring.get_password("system", name)
 
     if data:
         cache.deserialize(data)
@@ -144,13 +141,16 @@ def get_msal_cache() -> SerializableTokenCache:
     return cache
 
 
-def put_msal_cache(cache: SerializableTokenCache):
+def put_msal_cache(name: str, cache: SerializableTokenCache):
     if cache.has_state_changed:
         data = cache.serialize()
-        keyring.set_password("system", keyring_name, data)
+        keyring.set_password("system", name, data)
 
 
-def get_http_cache():
+def get_http_cache(name: str) -> dict:
+    http_cache_dir = os.path.join(xdg.BaseDirectory.xdg_cache_home, "git-credential-msal")
+    os.makedirs(http_cache_dir, exist_ok=True)
+    http_cache_path = os.path.join(http_cache_dir, name)
     try:
         with open(http_cache_path, "rb") as f:
             http_cache = pickle.load(f)
@@ -159,7 +159,8 @@ def get_http_cache():
     return http_cache
 
 
-def put_http_cache(http_cache):
+def put_http_cache(name: str, http_cache: dict):
+    http_cache_path = os.path.join(xdg.BaseDirectory.xdg_cache_home, name)
     pickle.dump(http_cache, open(http_cache_path, "wb"))
 
 
@@ -182,8 +183,10 @@ def msal_acquire_oidc_id_token(
 ) -> str:
     scopes = ["email openid User.Read"]
     id_token = None
-    cache = get_msal_cache()
-    http_cache = get_http_cache()
+    cache_name = f"{tenant_id}_{client_id}"
+    keyring_name = f"git-credential-msal_{cache_name}"
+    cache = get_msal_cache(keyring_name)
+    http_cache = get_http_cache(cache_name)
 
     app = PublicClientApplication(
         client_id=client_id,
@@ -229,8 +232,8 @@ def msal_acquire_oidc_id_token(
             },
         )[0]["secret"]
 
-    put_msal_cache(cache)
-    put_http_cache(http_cache)
+    put_msal_cache(keyring_name, cache)
+    put_http_cache(keyring_name, http_cache)
     return id_token
 
 


### PR DESCRIPTION
Valid authentication cache for a certain tenant-id / client-id pair should not be re-used when a user specifies a different pair, whether as an update to the same remote repository settings or the addition of a new remote. Likewise, authentication cache retrieved for a newly configured tenant-id / client-id pair should not clobber the cache of a previously used pair.