### PR TITLE
Support standard collection type hinting generics in python<3.9

### DIFF
--- a/src/git_credential_msal/main.py
+++ b/src/git_credential_msal/main.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: MIT
 
+# Bring standard collection type hinting generics to python<3.9
+from __future__ import annotations
+
 # pip install msal
 from msal import PublicClientApplication
 from msal import SerializableTokenCache


### PR DESCRIPTION
Python 3.7 and above offer a pathway to avoid depending on specialized type hinting annotations for collections that were deprecated in python 3.9. Import the annotation support from __future__ to keep the program compatible with python>=3.8.1.