### PR TITLE
Require PyJWT >=2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 dependencies = [
     "keyring",
     "msal",
-    "pyjwt",
+    "pyjwt>=2.0.0",
     "pyxdg",
 ]
 requires-python = ">=3.8.1"


### PR DESCRIPTION
Previous versions of PyJWT are unsupported for the JWT expiration check.