### PR TITLE
Replace "Z" with "+00:00" for datetime.fromisoformat

### DIFF
--- a/src/git_credential_msal/main.py
+++ b/src/git_credential_msal/main.py
@@ -207,7 +207,7 @@ def jwt_expired_value(token: str) -> int:
 
     token_exp = token_decoded["exp"]
     # Convert JWT exp NumericDate attribute to Python datetime object
-    token_exp_datetime = datetime.fromisoformat("1970-01-01T00:00:00Z") + timedelta(
+    token_exp_datetime = datetime.fromisoformat("1970-01-01T00:00:00+00:00") + timedelta(
         seconds=token_exp
     )
 


### PR DESCRIPTION
Some versions of python are not able to parse "Z" in ISO strings. Replace static usage of "Z" with "+00:00"