### PR TITLE
Add logic to verify if git is present and git version meets requirements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@ post](https://binary-eater.github.io/posts/git_oidc/).
 
 ## Dependencies
 
-Required dependencies
+### Must be manually installed by the user
+
+-   `git>=2.46`
+    - [Installation instructions](https://git-scm.com/downloads)
+      - [Linux/UNIX](https://git-scm.com/downloads/linux)
+      - [Windows](https://git-scm.com/downloads/win)
+      - [macOS](https://git-scm.com/downloads/mac)
+    - [Related changelog entry](https://github.com/git/git/blob/b31fb630c0fc6869a33ed717163e8a1210460d94/Documentation/RelNotes/2.46.0.txt#L10-L12)
+    - [Related commit](https://github.com/git/git/commit/789ec5bd359aae0dcaacf3e3d0eb8bb00bd827bf)
+
+### Handled by the installation process
 
 -   `msal-python`
 -   `pyjwt`

--- a/src/git_credential_msal/main.py
+++ b/src/git_credential_msal/main.py
@@ -304,6 +304,13 @@ def main():
 
     # Make sure the git implementation supports the `authtype` token.
     if not authtype_accepted(helper_pairs):
+        print(
+            """git support for the "authtype" credential field is required for git-credential-msal""",
+            file=sys.stderr,
+        )
+        print(
+            "Please make sure git version 2.46 or newer is installed", file=sys.stderr
+        )
         exit(0)
 
     # Make sure the server specified that a Bearer token is acceptable.

--- a/src/git_credential_msal/main.py
+++ b/src/git_credential_msal/main.py
@@ -17,15 +17,15 @@ from datetime import timezone
 # pip install keyring
 import keyring
 
+# pip install pyxdg
+import xdg.BaseDirectory
+
 import argparse
 import os
 import pickle
 import re
 import subprocess
 import sys
-
-# pip install pyxdg
-import xdg.BaseDirectory
 
 from importlib.metadata import version, PackageNotFoundError
 

--- a/src/git_credential_msal/main.py
+++ b/src/git_credential_msal/main.py
@@ -210,9 +210,9 @@ def jwt_expired_value(token: str) -> int:
 
     token_exp = token_decoded["exp"]
     # Convert JWT exp NumericDate attribute to Python datetime object
-    token_exp_datetime = datetime.fromisoformat("1970-01-01T00:00:00+00:00") + timedelta(
-        seconds=token_exp
-    )
+    token_exp_datetime = datetime.fromisoformat(
+        "1970-01-01T00:00:00+00:00"
+    ) + timedelta(seconds=token_exp)
 
     return int(token_exp_datetime.timestamp())
 


### PR DESCRIPTION
Now that support for various authentication schemes is available in git
2.46, add explicit version checking in the credential helper program to
prevent incorrect usage in an invalid setup.

### Example of the guarding logic

```
❯ git pull
Found git version 2.44.1. git>=2.46 is required to use git-credential-msal.
Username for 'XXXXXXXXXX': 
```

### Example of program working with git 2.47

```
❯ git pull
remote: Enumerating objects: 6742, done.
remote: Counting objects: 100% (6742/6742), done.
remote: Compressing objects: 100% (3063/3063), done.
remote: Total 6742 (delta 3559), reused 6507 (delta 3466), pack-reused 0 (from 0)
Receiving objects: 100% (6742/6742), 2.34 MiB | 3.14 MiB/s, done.
Resolving deltas: 100% (3559/3559), completed with 22 local objects.
....
```